### PR TITLE
Added files to show battlegrid, first draft

### DIFF
--- a/team/m3/js/grid.js
+++ b/team/m3/js/grid.js
@@ -1,0 +1,34 @@
+document.getElementById('create-grid').addEventListener('click', function() {
+    const width = parseInt(document.getElementById('grid-width').value);
+    const height = parseInt(document.getElementById('grid-height').value);
+    createGrid(width, height);
+});
+
+function createGrid(width, height) {
+    const battleGrid = document.getElementById('battle-grid');
+    battleGrid.innerHTML = ''; // Clear any existing grid
+    battleGrid.style.gridTemplateColumns = `repeat(${width}, 1fr)`;
+    battleGrid.style.gridTemplateRows = `repeat(${height}, 1fr)`;
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const tile = document.createElement('div');
+            tile.classList.add('grid-tile');
+            tile.addEventListener('click', () => {
+                // Toggle terrain type on click
+                if (tile.classList.contains('grass')) {
+                    tile.classList.remove('grass');
+                    tile.classList.add('stone');
+                } else if (tile.classList.contains('stone')) {
+                    tile.classList.remove('stone');
+                    tile.classList.add('castle');
+                } else if (tile.classList.contains('castle')) {
+                    tile.classList.remove('castle');
+                } else {
+                    tile.classList.add('grass');
+                }
+            });
+            battleGrid.appendChild(tile);
+        }
+    }
+}

--- a/team/m3/js/tile.js
+++ b/team/m3/js/tile.js
@@ -1,0 +1,34 @@
+// temp code for the battle grid to store information of what is on the tiles
+//not sure how to implement it so far into my grid but will try to do it later? 
+
+class Tile {
+    constructor() {
+        this.terrain = null;
+        this.tokens = [];
+    }
+
+    setTerrain(terrain) {
+        this.terrain = terrain;
+    }
+
+    addToken(token) {
+        this.tokens.push(token);
+    }
+
+    removeToken(token) {
+        const index = this.tokens.indexOf(token);
+        if (index > -1) {
+            this.tokens.splice(index, 1);
+        }
+    }
+
+    getTerrain() {
+        return this.terrain;
+    }
+
+    getTokens() {
+        return this.tokens;
+    }
+}
+
+export default Tile;

--- a/team/m3/main.html
+++ b/team/m3/main.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset = "UTF-8">
+    <meta name = "viewport" content = "width=device-width, initial-scale=1.0">
+    <title>TacTile - Customizable Battle Grid</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <div class="sidebar">
+            <h1>TacTile - Customizable Battle Grid</h1>
+            <div>
+                <label for="grid-width">Grid Width:</label>
+                <input type="number" id="grid-width" name="grid-width" min="1" max="100">
+                <label for="grid-height">Grid Height:</label>
+                <input type="number" id="grid-height" name="grid-height" min="1" max="100">
+                <button id="create-grid">Create Grid</button>
+            </div>
+        </div>
+        <div class="main-content">
+            <div id="battle-grid"></div>
+        </div>
+    </div>
+    <script src="js/grid.js"></script>
+</body>
+</html>

--- a/team/m3/styles.css
+++ b/team/m3/styles.css
@@ -1,0 +1,62 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    height: 100vh;
+    background-color: #f0f0f0;
+  }
+  
+  .container {
+    display: flex;
+    width: 100%;
+    height: 100%;
+  }
+  
+  .sidebar {
+    width: 30%;
+    padding: 20px;
+  }
+  
+  .main-content {
+    width: 70%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+  }
+  
+  #battle-grid {
+    display: grid;
+    gap: 1px;
+    margin-top: 20px;
+    justify-content: center;
+    /* Controls the size of the grid itself being displayed */
+    width: 90%; 
+    height: 90%;
+  }
+  
+  .grid-tile {
+    width: 100%; /* Make each tile take the full width of its grid cell */
+    height: 100%; /* Make each tile take the full height of its grid cell */
+    border: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  
+  /* temporary colors and options for the types on the grid
+  Geri, look over this and change to what you need to do with objects. */
+  .grid-tile.grass {
+    background-color: green;
+  }
+  
+  .grid-tile.stone {
+    background-color: gray;
+  }
+  
+  .grid-tile.castle {
+    background-color: brown;
+  }


### PR DESCRIPTION
Created a html, css, and two js files (which are under the folder js) to display a first draft of the battlemap. It should theoretically fit in any window size regardless of how many tiles you set the width and height as, and if you have a lot of width and height (for example, 20 by 20), it should all fit on one screen and not need to scroll down on the website to see the whole thing. Added basic text input to control the size of the grid, and when you click on the grids you can change the colors to 3 temp terrains (Green is grass, grey is stone, brown is castle). Tried to implement and added a beginning idea of the Tile object class to control what terrain type and what token is stored in which tile, but it doesnt do anything quite yet for the code. Will figure out how to implement it into the tiles later, might be more of taking Emily and Geri's things and pushing them onto this feature. Make sure you can see a grid of any size fit on your screen. 